### PR TITLE
Fix regex parsing problem

### DIFF
--- a/src/main/antlr4/nl/bigo/ecmascriptparser/ECMAScript.g4
+++ b/src/main/antlr4/nl/bigo/ecmascriptparser/ECMAScript.g4
@@ -1492,4 +1492,5 @@ fragment RegularExpressionClass
 ///     RegularExpressionBackslashSequence
 fragment RegularExpressionClassChar
  : ~[\r\n\u2028\u2029\]\\]
+ | RegularExpressionBackslashSequence
  ;


### PR DESCRIPTION
After looking at the parser trace I found the production rule which was causing the problem. Based on the comment above  "fragment RegularExpressionClassChar" I think it should also include "RegularExpressionBackslashSequence".

This fixes #2 .
